### PR TITLE
Fix type-only imports for verbatimModuleSyntax

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import UserForm from './components/UserForm';
 import UsersList from './components/UsersList';
 import ConversationList from './components/ConversationList';
 import ConversationDetails from './components/ConversationDetails';
-import { User, Conversation, Message } from './types';
+import type { User, Conversation, Message } from './types';
 
 function App() {
   const [users, setUsers] = useState<User[]>([]);

--- a/frontend/src/components/ConversationDetails.tsx
+++ b/frontend/src/components/ConversationDetails.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Conversation, User } from '../types';
+import { useState, type FormEvent } from 'react';
+import type { Conversation, User } from '../types';
 
 type Props = {
   conversation: Conversation | null;
@@ -16,7 +16,7 @@ export default function ConversationDetails({ conversation, users, onSendMessage
     return users.find((u) => u.id === id)?.name || 'Unknown';
   }
 
-  function handleSend(e: React.FormEvent) {
+  function handleSend(e: FormEvent) {
     e.preventDefault();
     if (!text.trim()) return;
     onSendMessage(text);

--- a/frontend/src/components/ConversationList.tsx
+++ b/frontend/src/components/ConversationList.tsx
@@ -1,4 +1,4 @@
-import { Conversation } from '../types';
+import type { Conversation } from '../types';
 
 type Props = {
   conversations: Conversation[];

--- a/frontend/src/components/UserForm.tsx
+++ b/frontend/src/components/UserForm.tsx
@@ -1,5 +1,5 @@
-import { useState, FormEvent } from 'react';
-import { User } from '../types';
+import { useState, type FormEvent } from 'react';
+import type { User } from '../types';
 
 type Props = {
   onCreate: (user: User) => void;

--- a/frontend/src/components/UsersList.tsx
+++ b/frontend/src/components/UsersList.tsx
@@ -1,4 +1,4 @@
-import { User } from '../types';
+import type { User } from '../types';
 
 type Props = {
   users: User[];

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- update import statements in React components to use type-only syntax
- add a vite env declaration file

## Testing
- `npm run build`
- `npm run dev` (started then stopped)

------
https://chatgpt.com/codex/tasks/task_e_6855145a0aac83269b4eaa6c73f676eb