### PR TITLE
Enhance UI and add logout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,5 @@
 #root {
-  max-width: 1280px;
+  max-width: 900px;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
@@ -39,4 +39,76 @@
 
 .read-the-docs {
   color: #888;
+}
+
+/* Custom styles for the messaging app */
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.auth-forms {
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.main-content {
+  display: flex;
+  gap: 2rem;
+}
+
+.sidebar {
+  width: 220px;
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.details {
+  flex-grow: 1;
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.conversation-details ul {
+  list-style: none;
+  padding: 0;
+  text-align: left;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.conversation-details li {
+  margin-bottom: 0.5rem;
+}
+
+.user-form {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.user-form input {
+  padding: 0.4rem;
+}
+
+.conversation-list ul {
+  list-style: none;
+  padding: 0;
+}
+
+.logout {
+  background-color: #ff6666;
+  color: #fff;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -197,52 +197,69 @@ function App() {
   }
 
   const userConvs = currentUser
-      ? conversations.filter((c) => c.participants.some((p) => String(p.id) === String(currentUser.id)))
-      : [];
+    ? conversations.filter((c) =>
+        c.participants.some((p) => String(p.id) === String(currentUser.id)),
+      )
+    : [];
 
   const otherUsers = currentUser
-      ? users.filter((u) => u.id !== currentUser.id)
-      : [];
+    ? users.filter((u) => u.id !== currentUser.id)
+    : [];
+
+  function handleLogout() {
+    localStorage.removeItem('token');
+    window.location.reload();
+  }
 
   return (
-      <div className="App">
+    <div className="App">
+      <header className="header">
         <h1>Messagerie</h1>
-        {!currentUser && (
-          <div>
-            <RegisterForm onRegister={handleRegister} />
-            <LoginForm onLogin={handleLogin} />
+        {currentUser && (
+          <div className="user-info">
+            <span>Bienvenue {currentUser.username}</span>
+            <button className="logout" onClick={handleLogout}>
+              Déconnexion
+            </button>
           </div>
         )}
-        {currentUser && (
-            <div style={{ display: 'flex', gap: '2rem', marginTop: '1rem' }}>
-              <div>
-                <h2>Bienvenue {currentUser.username}</h2>
-                {otherUsers.length > 0 && (
-                    <div>
-                      <h4>Démarrer une conversation</h4>
-                      {otherUsers.map((u) => (
-                          <button
-                              key={u.id}
-                              onClick={() => handleStartConversation(u)}
-                              style={{ marginRight: '0.5rem' }}
-                          >
-                            Avec {u.username}
-                          </button>
-                      ))}
-                    </div>
-                )}
-                <ConversationList
-                    conversations={userConvs}
-                    onSelect={handleSelectConv}
-                />
+      </header>
+      {!currentUser && (
+        <div className="auth-forms">
+          <RegisterForm onRegister={handleRegister} />
+          <LoginForm onLogin={handleLogin} />
+        </div>
+      )}
+      {currentUser && (
+        <div className="main-content">
+          <div className="sidebar">
+            {otherUsers.length > 0 && (
+              <div className="start-conv">
+                <h4>Démarrer une conversation</h4>
+                {otherUsers.map((u) => (
+                  <button
+                    key={u.id}
+                    onClick={() => handleStartConversation(u)}
+                  >
+                    Avec {u.username}
+                  </button>
+                ))}
               </div>
-              <ConversationDetails
-                  conversation={selectedConv}
-                  onSendMessage={handleSendMessage}
-              />
-            </div>
-        )}
-      </div>
+            )}
+            <ConversationList
+              conversations={userConvs}
+              onSelect={handleSelectConv}
+            />
+          </div>
+          <div className="details">
+            <ConversationDetails
+              conversation={selectedConv}
+              onSendMessage={handleSendMessage}
+            />
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/components/ConversationDetails.tsx
+++ b/frontend/src/components/ConversationDetails.tsx
@@ -7,9 +7,8 @@ type Props = {
 };
 
 export default function ConversationDetails({ conversation, onSendMessage }: Props) {
-  if (!conversation) return <div>Sélectionnez une conversation</div>;
-
   const [text, setText] = useState('');
+  if (!conversation) return <div className="conversation-details">Sélectionnez une conversation</div>;
 
 
 
@@ -21,7 +20,7 @@ export default function ConversationDetails({ conversation, onSendMessage }: Pro
   }
 
   return (
-    <div>
+    <div className="conversation-details">
       <h3>Détails de la conversation</h3>
       <ul>
         {conversation.messages.map((m) => (

--- a/frontend/src/components/ConversationList.tsx
+++ b/frontend/src/components/ConversationList.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function ConversationList({ conversations, onSelect }: Props) {
   return (
-    <div>
+    <div className="conversation-list">
       <h3>Conversations</h3>
       <ul>
         {conversations.map((c) => {

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -15,7 +15,7 @@ export default function LoginForm({ onLogin }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+    <form onSubmit={handleSubmit} className="user-form">
       <h3>Connexion</h3>
       <input
         placeholder="Nom d'utilisateur"

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -15,7 +15,7 @@ export default function RegisterForm({ onRegister }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+    <form onSubmit={handleSubmit} className="user-form">
       <h3>Inscription</h3>
       <input
         placeholder="Nom d'utilisateur"

--- a/frontend/src/components/UserForm.tsx
+++ b/frontend/src/components/UserForm.tsx
@@ -14,7 +14,7 @@ export default function UserForm({ onCreate }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+    <form onSubmit={handleSubmit} className="user-form">
       <input
         value={name}
         onChange={(e) => setName(e.target.value)}

--- a/frontend/src/components/UsersList.tsx
+++ b/frontend/src/components/UsersList.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function UsersList({ users, onSelect }: Props) {
   return (
-    <div>
+    <div className="users-list">
       <h3>Utilisateurs</h3>
       <ul>
         {users.map((u) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #213547;
+  background-color: #f5f5f5;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- style the frontend with a simple layout
- show forms and conversations in organized panels
- allow users to log out

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6866dd08484c8326a039745479b3e061